### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: csharp
 mono: none
-dotnet: 1.0.1
-dist: trusty
+dotnet: 2.0.3
 sudo: false
 cache:
   directories:


### PR DESCRIPTION
Move Travis build definition to latest .NET core version, to fix the build issue. Looks like 1.0.1 is not supported anymore. There is no impact because the build currently does not run .NET code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/azure-iot-pcs-remote-monitoring-dotnet/53)
<!-- Reviewable:end -->
