### PR TITLE
Allow to run local development without SSL certs on http://localhost/

### DIFF
--- a/reverse-proxy/Dockerfile
+++ b/reverse-proxy/Dockerfile
@@ -7,6 +7,8 @@ LABEL Tags="Azure,IoT,Solutions,Proxy,nginx"
 COPY ./content/ /app
 WORKDIR /app
 
+RUN mkdir /app/config/ && mv /app/nginx.conf /app/config/
+
 # TODO: remove port 80
 EXPOSE 80 443
 VOLUME ["/app/certs", "/app/config"]

--- a/reverse-proxy/content/run.sh
+++ b/reverse-proxy/content/run.sh
@@ -3,4 +3,4 @@ set -e
 set -x
 
 mkdir -p /app/logs
-nginx -c /app/nginx.conf
+nginx -c /app/config/nginx.conf

--- a/scripts/local/config/nginx.conf
+++ b/scripts/local/config/nginx.conf
@@ -1,6 +1,5 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-# TODO: add SSL and remove port 80
 # TODO: verify whether the resolver/DNS works (or has no impact) when running with Kubernetes
 # TODO: remove logs or move outside of the container
 
@@ -32,11 +31,7 @@ http {
 
     server {
         listen              80;
-        #listen              443 ssl;
-        #ssl                 on;
         server_name         reverseproxy 127.0.0.1;
-        #ssl_certificate     /app/certs/tls.crt;
-        #ssl_certificate_key /app/certs/tls.key;
 
         # Disable caching behavior for now
         # TODO: enable cache for static content later

--- a/scripts/local/docker-compose.yml
+++ b/scripts/local/docker-compose.yml
@@ -19,7 +19,7 @@ services:
   reverseproxy:
     image: azureiotpcs/remote-monitoring-nginx:testing
     ports:
-      - "80:80"
+      - "8080:80"
     depends_on:
       - webui
       - auth

--- a/scripts/local/docker-compose.yml
+++ b/scripts/local/docker-compose.yml
@@ -17,7 +17,8 @@ version: "3"
 
 services:
   reverseproxy:
-    image: azureiotpcs/remote-monitoring-nginx:testing
+    # Temporarily use the "testing-no-ssl" tag until the PR is merged and the new proxy docker image is published
+    image: azureiotpcs/remote-monitoring-nginx:testing-no-ssl
     ports:
       - "80:80"
       - "443:443"
@@ -29,8 +30,7 @@ services:
       - telemetry
       - config
     volumes:
-    # Required volume for app certs
-      - ./app/certs:/app/certs:ro
+      - ./nginx-no-ssl.conf:/app/config/nginx.conf:ro
 
   webui:
     image: azureiotpcs/pcs-remote-monitoring-webui:testing

--- a/scripts/local/docker-compose.yml
+++ b/scripts/local/docker-compose.yml
@@ -17,11 +17,9 @@ version: "3"
 
 services:
   reverseproxy:
-    # Temporarily use the "testing-no-ssl" tag until the PR is merged and the new proxy docker image is published
-    image: azureiotpcs/remote-monitoring-nginx:testing-no-ssl
+    image: azureiotpcs/remote-monitoring-nginx:testing
     ports:
       - "80:80"
-      - "443:443"
     depends_on:
       - webui
       - auth
@@ -30,7 +28,7 @@ services:
       - telemetry
       - config
     volumes:
-      - ./nginx-no-ssl.conf:/app/config/nginx.conf:ro
+      - ./config/nginx.conf:/app/config/nginx.conf:ro
 
   webui:
     image: azureiotpcs/pcs-remote-monitoring-webui:testing

--- a/scripts/local/nginx-no-ssl.conf
+++ b/scripts/local/nginx-no-ssl.conf
@@ -1,0 +1,141 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+# TODO: add SSL and remove port 80
+# TODO: verify whether the resolver/DNS works (or has no impact) when running with Kubernetes
+# TODO: remove logs or move outside of the container
+
+daemon                off;
+worker_processes      1;
+error_log             /app/logs/error.log;
+pid                   /app/logs/nginx.pid;
+worker_rlimit_nofile  131072;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    # Required so that nginx can resolve IPs when working with Docker Compose
+    resolver 127.0.0.11 ipv6=off;
+
+    include /etc/nginx/mime.types;
+    default_type text/plain;
+
+    index    index.html index.htm;
+
+    log_format upstreaminfo '$remote_addr - '
+        '[$proxy_add_x_forwarded_for] - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" '
+        '$request_length $request_time $upstream_addr $upstream_response_length $upstream_response_time $upstream_status';
+
+    access_log /app/logs/access.log  upstreaminfo;
+    error_log  /app/logs/error.log;
+
+    server {
+        listen              80;
+        #listen              443 ssl;
+        #ssl                 on;
+        server_name         reverseproxy 127.0.0.1;
+        #ssl_certificate     /app/certs/tls.crt;
+        #ssl_certificate_key /app/certs/tls.key;
+
+        # Disable caching behavior for now
+        # TODO: enable cache for static content later
+        add_header Cache-Control "no-cache";
+        expires 0;
+
+        # when serving any content, include a X-Content-Type-Options: nosniff
+        # header along with the Content-Type: header, to disable content-type
+        # sniffing on some browsers.
+        add_header X-Content-Type-Options "nosniff" always;
+
+        # Don't allow the browser to render the page inside a frame/iframe
+        # and avoid clickjacking http://en.wikipedia.org/wiki/Clickjacking
+        # If you need [i]frames, use SAMEORIGIN or set an uri with ALLOW-FROM uri
+        # See https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options
+        add_header X-Frame-Options SAMEORIGIN always;
+
+        set $webui_endpoint             "http://webui:80";
+        set $auth_endpoint              "http://auth:9001";
+        set $iothubmanager_endpoint     "http://iothubmanager:9002";
+        set $devicesimulation_endpoint  "http://devicesimulation:9003";
+        set $telemetry_endpoint         "http://telemetry:9004";
+        set $config_endpoint            "http://config:9005";
+
+        location / {
+            proxy_pass           $webui_endpoint;
+            proxy_pass_header    Authorization;
+            # TODO ~devis: remove - https://github.com/Azure/azure-iot-pcs-remote-monitoring-dotnet/issues/11
+            # Public preview only: used to distinguish internal/external traffic
+            proxy_set_header     X-Source external;
+            proxy_buffering      off;
+            client_max_body_size 0;
+            proxy_read_timeout   3600s;
+            proxy_redirect       off;
+        }
+
+        location /auth/ {
+            rewrite              /auth/(.*) /$1 break;
+            proxy_pass           $auth_endpoint;
+            proxy_pass_header    Authorization;
+            # TODO ~devis: remove - https://github.com/Azure/azure-iot-pcs-remote-monitoring-dotnet/issues/11
+            # Public preview only: used to distinguish internal/external traffic
+            proxy_set_header     X-Source external;
+            proxy_buffering      off;
+            client_max_body_size 0;
+            proxy_read_timeout   3600s;
+            proxy_redirect       off;
+        }
+
+        location /iothubmanager/ {
+            rewrite              /iothubmanager/(.*) /$1 break;
+            proxy_pass           $iothubmanager_endpoint;
+            proxy_pass_header    Authorization;
+            # TODO ~devis: remove - https://github.com/Azure/azure-iot-pcs-remote-monitoring-dotnet/issues/11
+            # Public preview only: used to distinguish internal/external traffic
+            proxy_set_header     X-Source external;
+            proxy_buffering      off;
+            client_max_body_size 0;
+            proxy_read_timeout   3600s;
+            proxy_redirect       off;
+        }
+
+        location /devicesimulation/ {
+            rewrite              /devicesimulation/(.*) /$1 break;
+            proxy_pass           $devicesimulation_endpoint;
+            proxy_pass_header    Authorization;
+            # TODO ~devis: remove - https://github.com/Azure/azure-iot-pcs-remote-monitoring-dotnet/issues/11
+            # Public preview only: used to distinguish internal/external traffic
+            proxy_set_header     X-Source external;
+            proxy_buffering      off;
+            client_max_body_size 0;
+            proxy_read_timeout   3600s;
+            proxy_redirect       off;
+        }
+
+        location /telemetry/ {
+            rewrite              /telemetry/(.*) /$1 break;
+            proxy_pass           $telemetry_endpoint;
+            proxy_pass_header    Authorization;
+            # TODO ~devis: remove - https://github.com/Azure/azure-iot-pcs-remote-monitoring-dotnet/issues/11
+            # Public preview only: used to distinguish internal/external traffic
+            proxy_set_header     X-Source external;
+            proxy_buffering      off;
+            client_max_body_size 0;
+            proxy_read_timeout   3600s;
+            proxy_redirect       off;
+        }
+
+        location /config/ {
+            rewrite              /config/(.*) /$1 break;
+            proxy_pass           $config_endpoint;
+            proxy_pass_header    Authorization;
+            # TODO ~devis: remove - https://github.com/Azure/azure-iot-pcs-remote-monitoring-dotnet/issues/11
+            # Public preview only: used to distinguish internal/external traffic
+            proxy_set_header     X-Source external;
+            proxy_buffering      off;
+            client_max_body_size 0;
+            proxy_read_timeout   3600s;
+            proxy_redirect       off;
+        }
+    }
+}


### PR DESCRIPTION

# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [x] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change

TODO before closing PR:
1. build and publish new Docker image “azureiotpcs/remote-monitoring-nginx       testing”
2. replace “testing-no-ssl” with “testing” in the docker compose file
3. update docs (Avni)

# Motivation for the change

Make local development easier, removing the need for self-signed certs. Also allow overriding the reverse proxy settings if needed. (this was meant to be possible but never tested, so it's a bug fix)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/azure-iot-pcs-remote-monitoring-dotnet/60)
<!-- Reviewable:end -->
