### PR TITLE
Docker container excessively privileged running root user

### DIFF
--- a/reverse-proxy/Dockerfile
+++ b/reverse-proxy/Dockerfile
@@ -4,9 +4,9 @@ MAINTAINER Devis Lucato (https://github.com/dluc)
 
 LABEL Tags="Azure,IoT,Solutions,Proxy,nginx"
 
-ARG user=pcsuser
+ARG user=app
 
-RUN useradd -m -s /bin/bash -U $user
+RUN groupadd $user && useradd --no-log-init -r -g $user $user
 
 COPY ./content/ /app
 RUN  mkdir -p /app/config/ && mv /app/nginx.conf /app/config/ \
@@ -15,8 +15,8 @@ RUN  mkdir -p /app/config/ && mv /app/nginx.conf /app/config/ \
  && chown -R $user:$user /var/lib/nginx /var/cache/nginx /var/tmp/nginx
 WORKDIR /app
 
-# TODO: remove port 8080
-EXPOSE 8080 8443
+# TODO: remove port 10080
+EXPOSE 10080 10443
 VOLUME ["/app/certs", "/app/config"]
 
 ENTRYPOINT ["/bin/bash", "/app/run.sh"]

--- a/reverse-proxy/Dockerfile
+++ b/reverse-proxy/Dockerfile
@@ -4,13 +4,21 @@ MAINTAINER Devis Lucato (https://github.com/dluc)
 
 LABEL Tags="Azure,IoT,Solutions,Proxy,nginx"
 
+ARG user=pcsuser
+
+RUN useradd -m -s /bin/bash -U $user
+
 COPY ./content/ /app
+RUN  mkdir -p /app/config/ && mv /app/nginx.conf /app/config/ \
+ && chown -R $user:$user /app \
+ && mkdir -p /var/lib/nginx /var/cache/nginx /var/tmp/nginx \
+ && chown -R $user:$user /var/lib/nginx /var/cache/nginx /var/tmp/nginx
 WORKDIR /app
 
-RUN mkdir /app/config/ && mv /app/nginx.conf /app/config/
-
-# TODO: remove port 80
-EXPOSE 80 443
+# TODO: remove port 8080
+EXPOSE 8080 8443
 VOLUME ["/app/certs", "/app/config"]
 
 ENTRYPOINT ["/bin/bash", "/app/run.sh"]
+
+USER $user

--- a/reverse-proxy/content/nginx.conf
+++ b/reverse-proxy/content/nginx.conf
@@ -31,8 +31,8 @@ http {
     error_log  /app/logs/error.log;
 
     server {
-        listen              8080;
-        listen              8443 ssl;
+        listen              10080;
+        listen              10443 ssl;
         ssl                 on;
         server_name         reverseproxy 127.0.0.1;
         ssl_certificate     /app/certs/tls.crt;
@@ -54,7 +54,7 @@ http {
         # See https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options
         add_header X-Frame-Options SAMEORIGIN always;
 
-        set $webui_endpoint             "http://webui:8080";
+        set $webui_endpoint             "http://webui:10080";
         set $auth_endpoint              "http://auth:9001";
         set $iothubmanager_endpoint     "http://iothubmanager:9002";
         set $devicesimulation_endpoint  "http://devicesimulation:9003";

--- a/reverse-proxy/content/nginx.conf
+++ b/reverse-proxy/content/nginx.conf
@@ -31,8 +31,8 @@ http {
     error_log  /app/logs/error.log;
 
     server {
-        listen              80;
-        listen              443 ssl;
+        listen              8080;
+        listen              8443 ssl;
         ssl                 on;
         server_name         reverseproxy 127.0.0.1;
         ssl_certificate     /app/certs/tls.crt;
@@ -54,7 +54,7 @@ http {
         # See https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options
         add_header X-Frame-Options SAMEORIGIN always;
 
-        set $webui_endpoint             "http://webui:80";
+        set $webui_endpoint             "http://webui:8080";
         set $auth_endpoint              "http://auth:9001";
         set $iothubmanager_endpoint     "http://iothubmanager:9002";
         set $devicesimulation_endpoint  "http://devicesimulation:9003";

--- a/reverse-proxy/run
+++ b/reverse-proxy/run
@@ -7,6 +7,6 @@ PORT=10080
 set -e
 
 echo Using port $PORT...
-docker run -it -p $PORT:8080 $DOCKER_IMAGE
+docker run -it -p $PORT:10080 $DOCKER_IMAGE
 
 set +e

--- a/reverse-proxy/run
+++ b/reverse-proxy/run
@@ -7,6 +7,6 @@ PORT=10080
 set -e
 
 echo Using port $PORT...
-docker run -it -p $PORT:80 $DOCKER_IMAGE
+docker run -it -p $PORT:8080 $DOCKER_IMAGE
 
 set +e


### PR DESCRIPTION
* Add default non-root user 'app'
* Run service as 'app'
* use ports 10080/10443

PBI[2211778]

# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
<!-- Please provide enough information so others can review your pull request -->
Without explicitly defining a running user in a Dockerfile definition, the root user is utilized by default.
Each respective Dockerfile should explicitly define a user and mandate that user to be the service runner via the USER instruction. Further, the service user should also have a defined GROUP. Without one, the primary group for the user will fall back to the root group.

# Motivation for the change
<!-- Please explain the motivation for making this change -->
...
