### PR TITLE
Fix issue #113 with updated local docker-compose

### DIFF
--- a/scripts/local/docker-compose.yml
+++ b/scripts/local/docker-compose.yml
@@ -54,17 +54,17 @@ services:
   iothubmanager:
     image: azureiotpcs/iothub-manager-dotnet:testing
     depends_on:
-      - storageadapter      
       - auth
+      - storageadapter
     environment:
       - PCS_IOTHUB_CONNSTRING
       - PCS_STORAGEADAPTER_WEBSERVICE_URL=http://storageadapter:9022/v1
+      - PCS_AUTH_WEBSERVICE_URL=http://auth:9001/v1
       - PCS_AUTH_ISSUER
       - PCS_AUTH_AUDIENCE
       - PCS_AUTH_REQUIRED
       - PCS_CORS_WHITELIST
       - PCS_APPLICATION_SECRET
-      - PCS_AUTH_WEBSERVICE_URL=http://auth:9001/v1
 
   devicesimulation:
     image: azureiotpcs/device-simulation-dotnet:testing
@@ -86,10 +86,12 @@ services:
   telemetry:
     image: azureiotpcs/telemetry-dotnet:testing
     depends_on:
+      - auth
       - storageadapter
     environment:
       - PCS_TELEMETRY_DOCUMENTDB_CONNSTRING
       - PCS_STORAGEADAPTER_WEBSERVICE_URL=http://storageadapter:9022/v1
+      - PCS_AUTH_WEBSERVICE_URL=http://auth:9001/v1
       - PCS_AUTH_ISSUER
       - PCS_AUTH_AUDIENCE
       - PCS_AUTH_REQUIRED
@@ -99,6 +101,7 @@ services:
   config:
     image: azureiotpcs/pcs-config-dotnet:testing
     depends_on:
+      - auth
       - storageadapter
       - devicesimulation
       - telemetry
@@ -107,6 +110,7 @@ services:
       - PCS_DEVICESIMULATION_WEBSERVICE_URL=http://devicesimulation:9003/v1
       - PCS_TELEMETRY_WEBSERVICE_URL=http://telemetry:9004/v1
       - PCS_AZUREMAPS_KEY
+      - PCS_AUTH_WEBSERVICE_URL=http://auth:9001/v1
       - PCS_AUTH_ISSUER
       - PCS_AUTH_AUDIENCE
       - PCS_AUTH_REQUIRED

--- a/scripts/local/docker-compose.yml
+++ b/scripts/local/docker-compose.yml
@@ -8,7 +8,7 @@
 # - note how this file references many environment variables, either set
 #   them in the .env file or edit this file adding the values here
 # - run `docker-compose up`
-# - open the browser at http://127.0.0.1:10443
+# - open the browser at http://127.0.0.1:8080
 #
 # For more information see
 # https://github.com/Azure/azure-iot-pcs-remote-monitoring-dotnet
@@ -54,7 +54,8 @@ services:
   iothubmanager:
     image: azureiotpcs/iothub-manager-dotnet:testing
     depends_on:
-      - storageadapter
+      - storageadapter      
+      - auth
     environment:
       - PCS_IOTHUB_CONNSTRING
       - PCS_STORAGEADAPTER_WEBSERVICE_URL=http://storageadapter:9022/v1
@@ -63,6 +64,7 @@ services:
       - PCS_AUTH_REQUIRED
       - PCS_CORS_WHITELIST
       - PCS_APPLICATION_SECRET
+      - PCS_AUTH_WEBSERVICE_URL=http://auth:9001/v1
 
   devicesimulation:
     image: azureiotpcs/device-simulation-dotnet:testing


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
Fix the relationship between the `iothubmanager` and `auth ` microservices by making changes in the docker-compose file for local deployment.
...

# Motivation for the change
When I pull the current version of this repo and attempt to follow the [Azure docs for the IOT Remote Monitoring solution accelerator](https://docs.microsoft.com/en-us/azure/iot-accelerators/iot-accelerators-remote-monitoring-deploy-local), I get similar errors like posted in issue #113 . In the container logs, the `iotmanager` container is failing, complaining about a missing `PCS_AUTH_WEBSERVICE_URL` parameter: 

```
iothubmanager_1     | [WebService.48a0b63c-c709-4c0e-8d56-026b04b41e7a][2018-08-01 17:34:42Z][ERROR][ConfigData:ProcessMandatoryPlaceholders] Environment variables not found, {"varsNotFound":", PCS_AUTH_WEBSERVICE_URL"}
iothubmanager_1     |
iothubmanager_1     | Unhandled Exception: Microsoft.Azure.IoTSolutions.IotHubManager.Services.Exceptions.InvalidConfigurationException: Environment variables not found: , PCS_AUTH_WEBSERVICE_URL
iothubmanager_1     |    at Microsoft.Azure.IoTSolutions.IotHubManager.Services.Runtime.ConfigData.ProcessMandatoryPlaceholders(String& value) in /home/azureiotpcs/vsts-agent/_work/14/s/iothub-manager/Services/Runtime/ConfigData.cs:line 109
iothubmanager_1     |    at Microsoft.Azure.IoTSolutions.IotHubManager.Services.Runtime.ConfigData.ReplaceEnvironmentVariables(String& value, String defaultValue) in /home/azureiotpcs/vsts-agent/_work/14/s/iothub-manager/Services/Runtime/ConfigData.cs:line 76
iothubmanager_1     |    at Microsoft.Azure.IoTSolutions.IotHubManager.Services.Runtime.ConfigData.GetString(String key, String defaultValue) in /home/azureiotpcs/vsts-agent/_work/14/s/iothub-manager/Services/Runtime/ConfigData.cs:line 42
iothubmanager_1     |    at Microsoft.Azure.IoTSolutions.IotHubManager.WebService.Runtime.Config..ctor(IConfigData configData) in /home/azureiotpcs/vsts-agent/_work/14/s/iothub-manager/WebService/Runtime/Config.cs:line 75
iothubmanager_1     |    at Microsoft.Azure.IoTSolutions.IotHubManager.WebService.Program.Main(String[] args) in /home/azureiotpcs/vsts-agent/_work/14/s/iothub-manager/WebService/Program.cs:line 22
iothubmanager_1     | /app/run.sh: line 6:     6 Aborted                 dotnet Microsoft.Azure.IoTSolutions.IotHubManager.WebService.dll
```
Once this container dies, the wheels come off and nothing seems to work. 
...
